### PR TITLE
int64 fun

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
-    "name": "@creditkarma/thrift-typescript",
-    "version": "3.7.6",
+    "name": "@mharris717/thrift-typescript",
+    "version": "3.8.1",
     "description": "Generate TypeScript from Thrift IDL files",
     "main": "./dist/main/index.js",
     "types": "./dist/main/index.d.ts",
+    "publishConfig": {
+        "registry": "https://npm.pkg.github.com/"
+    },
     "bin": {
         "thrift-typescript": "./dist/main/bin/index.js"
     },
@@ -39,7 +42,7 @@
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
-        "url": "https://github.com/creditkarma/thrift-typescript"
+        "url": "https://github.com/mharris717/thrift-typescript"
     },
     "dependencies": {
         "@creditkarma/thrift-parser": "^1.2.0",

--- a/src/main/render/apache/struct/create.ts
+++ b/src/main/render/apache/struct/create.ts
@@ -238,7 +238,7 @@ export function renderFieldDeclarations(
         [ts.createToken(ts.SyntaxKind.PublicKeyword)],
         ts.createIdentifier(field.name.value),
         renderOptional(field.requiredness),
-        typeNodeForFieldType(field.fieldType, state),
+        typeNodeForFieldType(field.fieldType, state, true),
         defaultValue,
     )
 }

--- a/src/main/render/apache/types.ts
+++ b/src/main/render/apache/types.ts
@@ -230,7 +230,7 @@ export function thriftTypeForFieldType(
 export function typeNodeForFieldType(
     fieldType: FunctionType,
     state: IRenderState,
-    loose: boolean = false,
+    loose: boolean = true,
 ): ts.TypeNode {
     switch (fieldType.type) {
         case SyntaxType.Identifier:

--- a/src/main/render/shared/includes.ts
+++ b/src/main/render/shared/includes.ts
@@ -7,6 +7,7 @@ import {
     FunctionDefinition,
     SyntaxType,
     ThriftStatement,
+    FunctionType,
 } from '@creditkarma/thrift-parser'
 
 import { Resolver } from '../../resolver'
@@ -59,6 +60,11 @@ function statementUsesThrift(statement: ThriftStatement): boolean {
     }
 }
 
+function containerValueTypes(field: FunctionType): FieldType[] {
+    let a = field as any
+    return [a.valueType, a.keyType].filter(x => x)
+}
+
 function statementUsesInt64(statement: ThriftStatement): boolean {
     switch (statement.type) {
         case SyntaxType.ServiceDefinition:
@@ -80,7 +86,11 @@ function statementUsesInt64(statement: ThriftStatement): boolean {
         case SyntaxType.UnionDefinition:
         case SyntaxType.ExceptionDefinition:
             return statement.fields.some((field: FieldDefinition) => {
-                return field.fieldType.type === SyntaxType.I64Keyword
+                let types = [
+                    ...containerValueTypes(field.fieldType),
+                    field.fieldType,
+                ]
+                return types.some(cf => cf.type === SyntaxType.I64Keyword)
             })
 
         case SyntaxType.NamespaceDefinition:


### PR DESCRIPTION
Two changes

**Int64 Imports**

The generator checks whether Int64 is used in the generated code. If so, it adds an Int64 import to that file. 

The code was not correctly checking container types, such as Map, Set and List. It was only checking if the type of the container itself was Int64, and ignoring the type the container holds. 

Container Types: https://github.com/creditkarma/thrift-parser/blob/master/src/main/types.ts#L115-L138

**Allowing number | Int64**

The generator wants the generated code to be developer friendly. It wants the generated code to accept `number | Int64` in some places, instead of just `Int64`. This means the user of the code can pass a number to the generated classes, instead of having to wrap the input in `new Int64`. 

There is a `loose` boolean argument to a generator method. If `loose=true`, it generates code with `number | Int64`. If `loose=false`, it generates `Int64` only. This argument defaults to false. 

One caller of this function was not passing `loose=true` when it should have, in order to agree with other callers generating different parts of the same class. Because the argument has a default, the generator still compiled. 